### PR TITLE
Radio head comms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Nanosat Revolution 
+
+## Introduction
+Nanosat revolution is a project to put a telescope into a cubesat and capture the resulting images to be published on itelescope.com. The project is based in melbourne. The project has a [main site](http://nanosatrevolution.com). we are also using [slack] (nanosatrevolution.slack.com) for discussing and keeping ourselves up to date.
+
+## The codebase
+This repository contains the code for an arduino based prototype. The prototype will bring together a camera, comms modules operating at amateur frequencies, an Inertial measurement unit (IMU), solar power, and an attitude determination and control system to demostrate the base functionality of the satellite. We will also build ground station software that will receive the data and publish to a website. 
+
+## how you can help
+Please register on [nanosat revolution](http://nanosatrevolution.com). I will add you to the slack channels and you can follow along. We need people that understand:
+- arduino
+- *Nix based embedded software development (think ARM based systems like beaglebone, edison, raspberry PI)
+- Software Defined Radio (SDR) to manage comms b
+- optical instrument design and image processing ( to build the telescope payload).
+- aerospace concepts - orbits, attitude control, the space environment, etc.
+
+Finally, we have a [monthly meetup](http://meetu.ps/c/2xfcY/1jjZ5/a). we'd love to have you along. 
+

--- a/arduino-prototype/RF_RadioHead_Msg_RX/RF_RadioHead_Msg_RX.ino
+++ b/arduino-prototype/RF_RadioHead_Msg_RX/RF_RadioHead_Msg_RX.ino
@@ -1,0 +1,62 @@
+// receiving data reliably, from the radio example code: ask_reliable_datagram_server.pde
+// uses 433 MHz modules from IC Station: http://www.icstation.com/433mhz-transmitter-receiver-arduino-project-p-1402.html
+// power with 5V. 
+// connect data pin to pin 12 (or whatever you set)
+// I didn't need an antenna to get this going, but that's with devices 20cm from eachother.
+// see http://www.airspayce.com/mikem/arduino/RadioHead/classRH__ASK.html for more on how to use radio head and the ASK driver.
+// default set up is RH_ASK (uint16_t speed=2000, uint8_t rxPin=11, uint8_t txPin=12, uint8_t pttPin=10, bool pttInverted=false)
+// so, 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.
+
+#include <RHReliableDatagram.h>
+#include <RH_ASK.h>
+#include <SPI.h>
+
+#define CLIENT_ADDRESS 1
+#define SERVER_ADDRESS 2
+
+// Singleton instance of the radio driver
+RH_ASK driver;
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+
+// Class to manage message delivery and receipt, using the driver declared above
+RHReliableDatagram manager(driver, SERVER_ADDRESS);
+
+void setup() 
+{
+  Serial.begin(9600);
+  if (manager.init())
+  {
+    Serial.println("initialised ok");
+  }
+  else 
+  {
+    Serial.println("init failed");
+  }
+}
+
+uint8_t data[] = "And hello back to you";
+// Dont put this on the stack:
+uint8_t buf[RH_ASK_MAX_MESSAGE_LEN];
+
+void loop()
+{
+  if (manager.available())
+  {
+    // Wait for a message addressed to us from the client
+    uint8_t len = sizeof(buf);
+    uint8_t from;
+    if (manager.recvfromAck(buf, &len, &from))
+    {
+      Serial.print("got request from : 0x");
+      Serial.print(from, HEX);
+      Serial.print(": ");
+      Serial.println((char*)buf);
+
+      // Send a reply back to the originator client
+      if (!manager.sendtoWait(data, sizeof(data), from))
+        Serial.println("sending response failed");
+    }
+  }
+}
+
+

--- a/arduino-prototype/RF_RadioHead_Msg_TX/RF_RadioHead_Msg_TX.ino
+++ b/arduino-prototype/RF_RadioHead_Msg_TX/RF_RadioHead_Msg_TX.ino
@@ -1,0 +1,72 @@
+// sending data reliably, from the radio example code: ask_reliable_datagram_client.pde
+// uses 433 MHz modules from IC Station: http://www.icstation.com/433mhz-transmitter-receiver-arduino-project-p-1402.html
+// power with 5V. 
+// connect data pin to pin 12 (or whatever you set)
+// I didn't need an antenna to get this going, but that's with devices 20cm from eachother.
+// see http://www.airspayce.com/mikem/arduino/RadioHead/classRH__ASK.html for more on how to use radio head and the ASK driver.
+// default set up is RH_ASK (uint16_t speed=2000, uint8_t rxPin=11, uint8_t txPin=12, uint8_t pttPin=10, bool pttInverted=false)
+// so, 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.
+
+#include <RHReliableDatagram.h>
+#include <RH_ASK.h>
+#include <SPI.h>
+
+#define CLIENT_ADDRESS 1
+#define SERVER_ADDRESS 2
+
+// Singleton instance of the radio driver
+RH_ASK driver;
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+
+// Class to manage message delivery and receipt, using the driver declared above
+RHReliableDatagram manager(driver, CLIENT_ADDRESS);
+
+void setup() 
+{
+  Serial.begin(9600);
+  if (manager.init())
+  {
+    Serial.println("initialised ok");
+  }
+  else 
+  {
+    Serial.println("init failed");
+  }
+}
+
+
+
+void loop() 
+{
+  uint8_t data[] = "Hello World!";
+  // MJDS - why not - Dont put this on the stack:
+  uint8_t buf[RH_ASK_MAX_MESSAGE_LEN];
+
+  Serial.print("Sending to ask_reliable_datagram_server:");
+  Serial.print(sizeof(data));
+  Serial.println(": bytes");
+    
+  // Send a message to manager_server
+  if (manager.sendtoWait(data, sizeof(data), SERVER_ADDRESS))
+  {
+    // Now wait for a reply from the server
+    uint8_t len = sizeof(buf);
+    uint8_t from;   
+    if (manager.recvfromAckTimeout(buf, &len, 2000, &from))
+    {
+      Serial.print("got reply from : 0x");
+      Serial.print(from, HEX);
+      Serial.print(": ");
+      Serial.println((char*)buf);
+    }
+    else
+    {
+      Serial.println("No reply, is ask_reliable_datagram_server running?");
+    }
+  }
+  else
+    Serial.println("sendtoWait failed");
+  delay(500);
+}
+
+

--- a/arduino-prototype/RF_RadioHead_RX/RF_RadioHead_RX.ino
+++ b/arduino-prototype/RF_RadioHead_RX/RF_RadioHead_RX.ino
@@ -1,0 +1,53 @@
+// receiver based on the original from the radiohead example simple ASK receiver code
+// uses 433 MHz modules from IC Station: http://www.icstation.com/433mhz-transmitter-receiver-arduino-project-p-1402.html
+// power with 5V. 
+// connect data pin to pin 12 (or whatever you set)
+// I didn't need an antenna to get this going, but that's with devices 20cm from eachother.
+// see http://www.airspayce.com/mikem/arduino/RadioHead/classRH__ASK.html for more on how to use radio head and the ASK driver.
+// default set up is RH_ASK (uint16_t speed=2000, uint8_t rxPin=11, uint8_t txPin=12, uint8_t pttPin=10, bool pttInverted=false)
+// so, 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.
+// 
+
+#include <RH_ASK.h>
+#include <SPI.h> // Not actualy used but needed to compile
+
+RH_ASK driver; // by default uses 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+
+void setup()
+{
+    Serial.begin(9600);  // Debugging only
+    if (driver.init()) {
+      Serial.println("driver initialised ok");
+    } else {
+      Serial.println("init failed");
+    }
+}
+
+void loop()
+{
+    uint8_t buf[RH_ASK_MAX_MESSAGE_LEN];
+    uint8_t buflen = sizeof(buf);
+
+    if (driver.recv(buf, &buflen)) // Non-blocking
+    {
+      int i;
+      
+      // Message with a good checksum received, dump it.
+      // driver.printBuffer("Got:", buf, buflen);
+      dumpMsg(buf, buflen);
+    }
+}
+
+void dumpMsg(uint8_t *buf, uint8_t buflen)
+{
+    int i = 0;
+    Serial.print("Got ("); Serial.print(buflen); Serial.print(") bytes:");
+  
+    for (i = 0; i < buflen; i++)
+    {
+        Serial.print((char)buf[i]);
+    }
+    Serial.println();
+}
+

--- a/arduino-prototype/RF_RadioHead_TX/RF_RadioHead_TX.ino
+++ b/arduino-prototype/RF_RadioHead_TX/RF_RadioHead_TX.ino
@@ -1,0 +1,38 @@
+// transmitter based on the original from the radiohead example simple ASK transmitter code
+// uses 433 MHz modules from IC Station: http://www.icstation.com/433mhz-transmitter-receiver-arduino-project-p-1402.html
+// power with 5V. 
+// connect data pin to pin 12 (or whatever you set)
+// I didn't need an antenna to get this going, but that's with devices 20cm from eachother.
+// see http://www.airspayce.com/mikem/arduino/RadioHead/classRH__ASK.html for more on how to use radio head and the ASK driver.
+// default set up is RH_ASK (uint16_t speed=2000, uint8_t rxPin=11, uint8_t txPin=12, uint8_t pttPin=10, bool pttInverted=false)
+// so, 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.
+// 
+
+#include <RH_ASK.h>
+#include <SPI.h> // Not actually used but needed to compile
+
+RH_ASK driver; // by default uses 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.
+// RH_ASK driver(2000, 2, 4, 5); // ESP8266: do not use pin 11
+
+void setup()
+{
+    Serial.begin(9600);    // Debugging only
+    if (driver.init()) {
+      Serial.println("driver initialised ok");
+    } else {
+      Serial.println("init failed");
+    }
+}
+
+void loop()
+{
+    const char *msg = "Hello Radio Head";
+
+    Serial.print("Sending:");
+    Serial.print(msg);
+    driver.send((uint8_t *)msg, strlen(msg));
+    driver.waitPacketSent();
+    Serial.println(": complete");
+    delay(500);
+}
+


### PR DESCRIPTION
This branch introduces the radio head library for driving the [ASK modules from IC Station]( http://www.icstation.com/433mhz-transmitter-receiver-arduino-project-p-1402.html)
see http://www.airspayce.com/mikem/arduino/RadioHead/classRH__ASK.html for more on how to use radio head and the ASK driver.
default set up is RH_ASK (uint16_t speed=2000, uint8_t rxPin=11, uint8_t txPin=12, uint8_t pttPin=10, bool pttInverted=false)
so, 2000 bits per second, pin 11 for rx, pin 12 for tx, and ptt inverted.